### PR TITLE
Download the percipitation image before sending embed

### DIFF
--- a/arso.py
+++ b/arso.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import requests
+import io
 
 from requests.adapters import HTTPAdapter, Retry
 
@@ -46,3 +47,17 @@ class ARSO:
 
     def get_morn_even_table(self):
         return self.tg.generate_shorthand("morn_tabela.png")
+        
+    def get_percipitation_gif(self):
+        res = self.s.get("https://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm-anim.gif")
+        if res.status_code == 200:
+            image_data = io.BytesIO(res.content)
+            return image_data
+        return {
+            "header": "Napaka!",
+            "title": "Napaka!",
+            "body": f"Prišlo je do napake {res.status_code}",
+            "author": "you dummy",
+            "timestamp": datetime.now()
+        }
+        return 

--- a/main.py
+++ b/main.py
@@ -86,15 +86,19 @@ class ARSOClient(discord.Client):
         }
 
     def generate_precipitation_panel(self):
+        gif = self.arso.get_percipitation_gif()
+        filename = datetime.now().strftime("%Y%m%d-%H%M-si0-rm-anim.gif")
+        file = discord.File(gif, filename=filename)
+    
         embed = discord.Embed(color=color_to_discord(self.cu.get_current_color()), title="Radarska slika padavin")
         embed.set_footer(text='ARSO').timestamp = datetime.now()
         embed.set_author(name="Vir: Agencija Republike Slovenije za okolje",
                          url="https://meteo.arso.gov.si/met/sl/weather/observ/radar/")
         embed.set_thumbnail(url="https://pbs.twimg.com/profile_images/798099496139915264/cSjEl4nm_400x400.jpg")
-        embed.set_image(
-            url=f"https://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm-anim.gif?time={time.time()}")
+        embed.set_image(url=f"attachment://{filename}")
 
         return {
+            "file": file,
             "embed": embed
         }
 


### PR DESCRIPTION
This modification downloads the percipitation animation gif and then uploads it as an attachment to the message. This way the image sent is always the latest and will also not get refreshed later, when the cache expires.