### PR TITLE
Update html2image version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,11 @@ colour==0.1.5
 discord==2.1.0
 discord.py==2.1.1
 frozenlist==1.3.3
-html2image==2.0.1
+html2image==2.0.4.3
 idna==3.4
 imgkit==1.2.2
 multidict==6.0.4
+Pillow==9.4.0
 pytz==2022.7.1
 pytz-deprecation-shim==0.1.0.post0
 PyYAML==6.0
@@ -23,6 +24,5 @@ six==1.16.0
 tzdata==2022.7
 tzlocal==4.2
 urllib3==1.26.14
+websocket-client==1.7.0
 yarl==1.8.2
-
-Pillow~=9.4.0


### PR DESCRIPTION
This fixes a problem where html2image doesn't save a file because of an incorrect default argument.