### PR TITLE
Use chromium-headless-shell for screenshots

### DIFF
--- a/parsers/TableGenerator.py
+++ b/parsers/TableGenerator.py
@@ -13,7 +13,7 @@ class TableGenerator:
         self.folder = folder
         self.url = url
         self.css = css
-        self.hti = Html2Image(output_path=folder)
+        self.hti = Html2Image(output_path=folder, browser_executable="chromium-headless-shell")
 
     def generate_napoved(self, file):
         return self.generate_table(file, f"{self.url}/fcast_SLOVENIA_MIDDLE_latest.html", self.css,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,7 @@
 # An unofficial ARSO Discord bot
 Generates a config file when launched for the first time. Set your Discord bot token and launch it!
 
+## Requirements
+Along with the Python requirements in the `requirements.txt` file, the html2image library also needs a browser to generate screenshots. Due to compatibility reasons `chromium-headless-shell` is used and needs to be installed and in `PATH`.
+
 **NOTE: This bot is in no way affiliated with [ARSO](https://www.arso.gov.si/), but uses their official API to collect weather information.**

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ colour==0.1.5
 discord==2.1.0
 discord.py==2.1.1
 frozenlist==1.3.3
-html2image==2.0.4.3
+html2image==2.0.7
 idna==3.4
 imgkit==1.2.2
 multidict==6.0.4


### PR DESCRIPTION
The headless mode in Chromium was reimplemented. The new version appears to have some bugs (or functional differences) that make it not work with html2image, so this pull requests instead uses `chromium-headless-shell` which is a standalone implementation of the old headless mode.

https://issues.chromium.org/issues/405165895